### PR TITLE
Add sport filter to reservation URLs in messages for better booking accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,17 +226,17 @@ Cuando encuentra turnos disponibles, recibirás un email con el siguiente format
 🎾 ¡Hay turnos disponibles!
 
 📅 Lunes, 16 de Junio, 18:30 - 🏟️ Cancha 3
-🔗 Reservar: https://atcsports.io/venues/head-club-tandil-tandil?dia=2025-06-16
+🔗 Reservar: https://atcsports.io/venues/head-club-tandil-tandil?dia=2025-06-16&sportIds=7
 
 📅 Jueves, 19 de Junio, 19:00 - 🏟️ Cancha 1
-🔗 Reservar: https://atcsports.io/venues/head-club-tandil-tandil?dia=2025-06-19
+🔗 Reservar: https://atcsports.io/venues/head-club-tandil-tandil?dia=2025-06-19&sportIds=7
 ```
 
 Cada turno incluye:
 
 - 📅 **Fecha y hora**: En formato argentino (24 horas)
 - 🏟️ **Cancha**: Nombre de la cancha disponible
-- 🔗 **Link directo**: Para ir directamente a reservar en la web
+- 🔗 **Link directo**: Para ir directamente a reservar en la web, **con filtro automático de Pádel** (`sportIds=7`)
 
 ## Estructura del proyecto
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ function generateClubGroupedMessages(slots: Slot[]): string[] {
       turno = capitalizeWords(turno);
       
       const urlDate = getArgentinaDateString(date);
-      const reservationUrl = club.reservationUrlTemplate.replace('{date}', urlDate);
+      const reservationUrl = club.reservationUrlTemplate.replace('{date}', urlDate) + `&sportIds=${config.sports.padel}`;
       
       messages.push(`📅 ${turno} - 🏟️ ${slot.court}\n🔗 Reservar: ${reservationUrl}`);
     });

--- a/test-script.js
+++ b/test-script.js
@@ -67,7 +67,7 @@ function generateClubGroupedMessages(slots) {
       turno = capitalizeWords(turno);
       
       const urlDate = getArgentinaDateString(date);
-      const reservationUrl = club.reservationUrlTemplate.replace('{date}', urlDate);
+      const reservationUrl = club.reservationUrlTemplate.replace('{date}', urlDate) + `&sportIds=${config.sports.padel}`;
       
       messages.push(`📅 ${turno} - 🏟️ ${slot.court}\n🔗 Reservar: ${reservationUrl}`);
     });


### PR DESCRIPTION
This pull request introduces a change to include a Pádel-specific filter (`sportIds=7`) in reservation URLs across various parts of the codebase. This ensures that users are automatically directed to Pádel-related options when accessing reservation links.

### Updates to Reservation URLs:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L229-R239): Updated reservation links in example emails to include the Pádel-specific filter (`sportIds=7`) and clarified this addition in the description of the direct link.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L129-R129): Modified the `generateClubGroupedMessages` function to append the Pádel-specific filter (`sportIds=${config.sports.padel}`) to reservation URLs dynamically.
* [`test-script.js`](diffhunk://#diff-a6bf3129c763c30afdcdb79de813ca11dae432c8a7298331cc2d30014db2085cL70-R70): Adjusted the `generateClubGroupedMessages` function in the test script to match the production logic by including the Pádel-specific filter in reservation URLs.